### PR TITLE
type attribute

### DIFF
--- a/longest_bridges_chart.html
+++ b/longest_bridges_chart.html
@@ -8,7 +8,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js@3.5.1/dist/chart.min.js"></script>
 
     <!-- My script and CSS -->
-    <script async defer src="longest_bridges_chart.js"></script>
+    <script async defer type="module" src="longest_bridges_chart.js"></script>
     <link rel="stylesheet" type="text/css" href="longest_bridges_chart_styles.css">
 
 </head>

--- a/longest_bridges_chart.js
+++ b/longest_bridges_chart.js
@@ -1,3 +1,8 @@
+// It isn't going to make any difference to how your code works, but typically do the imports at the start
+// Import list of bridge data from bridges.js file
+import {bridges} from "./bridges.js";  
+
+
 let chartCanvas = document.querySelector('#bridges-chart')
 let ctx = chartCanvas.getContext('2d')
 
@@ -17,8 +22,6 @@ let bridgesChart = new Chart(ctx, {
     options: {}
 })
 
-// Import list of bridge data from bridges.js file
-import {bridges} from "./bridges";
 
 // For each bridge object in the bridges array, add the bridge span to the chart data array and add
 // the bridge name to the chart labels array.


### PR DESCRIPTION
It's just missing the type="module" attribute from the script element in your web page.  Also the .js extension is nice to have, there's other things that JS can read, for example typescript files, so specify the entire file name.    Unrelated to the errors, and you can import things anywhere, but usually put all the imports at the top of a file. 